### PR TITLE
メール認証&パスワードリセット

### DIFF
--- a/src/app/auth/action/page.tsx
+++ b/src/app/auth/action/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function FirebaseActionPage() {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const mode = searchParams.get('mode');      // 'verifyEmail' or 'resetPassword'
+    const oobCode = searchParams.get('oobCode'); // Firebaseの一時コード
+
+    useEffect(() => {
+        if (!mode || !oobCode) {
+        router.replace('/error');
+        return;
+        }
+
+        switch (mode) {
+        case 'verifyEmail':
+            router.replace(`/auth/verify?oobCode=${encodeURIComponent(oobCode)}`);
+            break;
+        case 'resetPassword':
+            router.replace(`/auth/set-new-password?oobCode=${encodeURIComponent(oobCode)}`);
+            break;
+        default:
+            router.replace('/error');
+            break;
+        }
+    }, [mode, oobCode]);
+
+    return (
+        <div className="flex items-center justify-center min-h-[calc(100vh-64px)]">
+                <p className="text-gray-600 text-2xl">リダイレクト中...</p>
+        </div>
+    );
+}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from "next/link";
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
@@ -28,10 +29,20 @@ export default function LoginPage() {
 
     const onSubmit = async (data: FormData) => {
         try {
-            await signIn(data.email, data.password);
-                alert('ログイン成功');
-                router.push('/');
-            } catch (error: any) {
+            const userCredential = await signIn(data.email, data.password);
+            const user = userCredential.user;
+
+            // メール確認済みかチェック
+            if (!user.emailVerified) {
+                alert('メールアドレスが確認されていません。メールを確認してください。');
+                // 必要に応じて確認ページに遷移
+                router.push('/auth/verify-email');
+            return;
+            }
+
+            alert('ログイン成功');
+            router.push('/');
+        } catch (error: any) {
             if (error.code === 'auth/user-not-found') {
                 setError('email', { type: 'manual', message: '登録されていないメールアドレスです。' });
             } else if (error.code === 'auth/wrong-password') {
@@ -45,7 +56,7 @@ export default function LoginPage() {
     };
 
     return (
-    <div className="w-[600px] mx-auto mt-30 p-6 border rounded">
+    <div className="w-[600px] mx-auto mt-30 p-6 border rounded text-center">
         <h1 className="text-2xl mb-4 text-center">ログイン</h1>
         <form onSubmit={handleSubmit(onSubmit)}>
             <input
@@ -70,6 +81,9 @@ export default function LoginPage() {
             ログイン
             </SubmitButton>
         </form>
+        <Link href="/auth/reset-password" className="inline-block text-blue-600 hover:underline text-sm mt-4">
+            パスワードを忘れた方はこちら
+        </Link>
     </div>
     );
 }

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -30,7 +30,7 @@ export default function RegisterPage() {
         try {
         await signUp(data.email, data.password, data.username);
             alert('登録に成功しました！');
-            router.push('/');
+            router.push('/auth/verify-email');
         } catch (error: any) {
         alert(error.message);
         }

--- a/src/app/auth/reset-password/page.tsx
+++ b/src/app/auth/reset-password/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+import { resetPassword } from '@/lib/firebaseAuth';
+import { useState } from 'react';
+import SubmitButton from '@/components/common/SubmitButton';
+
+const schema = yup.object({
+    email: yup.string().required('メールアドレスは必須です').email('メール形式が正しくありません'),
+});
+
+type FormData = {
+    email: string;
+};
+
+export default function ResetPasswordPage() {
+    const [message, setMessage] = useState('');
+    const {
+        register,
+        handleSubmit,
+        formState: { errors, isSubmitting },
+    } = useForm<FormData>({
+        resolver: yupResolver(schema),
+        mode: 'onChange',
+    });
+
+    const onSubmit = async (data: FormData) => {
+        try {
+        await resetPassword(data.email);
+        setMessage('パスワードリセットのメールを送信しました');
+        } catch (error: any) {
+        setMessage(error.message || 'エラーが発生しました');
+        }
+    };
+
+    return (
+    <div className="w-[600px] mx-auto mt-40 p-6 border rounded">
+        <h1 className="text-2xl mb-4 text-center">パスワードをリセット</h1>
+        <form onSubmit={handleSubmit(onSubmit)}>
+            <input
+            type="email"
+            placeholder="登録済みのメールアドレス"
+            {...register('email')}
+            className="w-full p-2 mb-2 border rounded"
+            />
+            {errors.email && <p className="text-red-500 text-sm mb-3">{errors.email.message}</p>}
+
+            <SubmitButton isSubmitting={isSubmitting}
+            className="w-full bg-blue-500 text-white p-2 rounded hover:bg-blue-600 disabled:opacity-50 mt-6"
+            >
+            送信
+            </SubmitButton>
+        </form>
+
+        {message && <p className="mt-4 text-center text-green-600">{message}</p>}
+    </div>
+    );
+}

--- a/src/app/auth/set-new-password/page.tsx
+++ b/src/app/auth/set-new-password/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { auth } from '@/lib/firebase';
+import {
+    verifyPasswordResetCode,
+    confirmPasswordReset,
+} from 'firebase/auth';
+
+export default function ResetPasswordPage() {
+    const searchParams = useSearchParams();
+    const router = useRouter();
+    const oobCode = searchParams.get('oobCode');
+
+    const [newPassword, setNewPassword] = useState('');
+    const [status, setStatus] = useState<'verifying' | 'verified' | 'error' | 'success'>('verifying');
+
+    useEffect(() => {
+        if (!oobCode) {
+        setStatus('error');
+        return;
+        }
+
+        verifyPasswordResetCode(auth, oobCode)
+        .then(() => setStatus('verified'))
+        .catch(() => setStatus('error'));
+    }, [oobCode]);
+
+    const handleReset = async () => {
+        if (!oobCode) return;
+        try {
+        await confirmPasswordReset(auth, oobCode, newPassword);
+        setStatus('success');
+        } catch {
+        setStatus('error');
+        }
+    };
+
+    if (status === 'verifying') {
+        return (
+            <div className="flex items-center justify-center min-h-[calc(100vh-64px)]">
+                <p className="text-gray-600 text-2xl">確認中...</p>
+            </div>
+        );
+    }
+    
+    if (status === 'error') {
+        return (
+            <div className="flex items-center justify-center min-h-[calc(100vh-64px)]">
+                <p className="text-red-500 text-2xl font-bold">無効なリンクです</p>
+            </div>
+        );
+    }
+
+    if (status === 'success') {
+        return (
+            <div className="flex flex-col justify-center min-h-[calc(100vh-64px)] text-center">
+                <p className="text-green-600 text-2xl">パスワードが変更されました！</p>
+                <button
+                    className="mt-6 px-4 py-2 bg-blue-500 text-white rounded"
+                    onClick={() => router.push('/auth/login')}
+                >
+                    ログインページへ戻る
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="max-w-md mx-auto mt-40 text-center">
+            <h1 className="text-2xl font-bold mb-4">新しいパスワードを入力</h1>
+            <input
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                placeholder="新しいパスワード"
+                className="border rounded p-2 w-full"
+            />
+            <button
+                onClick={handleReset}
+                className="mt-6 px-4 py-2 bg-blue-500 text-white rounded"
+            >
+                パスワードを変更
+            </button>
+        </div>
+    );
+}

--- a/src/app/auth/verify-email/page.tsx
+++ b/src/app/auth/verify-email/page.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useAuth } from '@/context/AuthContext';
+import { sendEmailVerification } from 'firebase/auth';
+import { useState } from 'react';
+
+export default function VerifyEmailPage() {
+    const { user } = useAuth();
+    const [message, setMessage] = useState('');
+
+    const handleResend = async () => {
+        if (user) {
+        await sendEmailVerification(user);
+        setMessage('確認メールを再送信しました。');
+        }
+    };
+
+    return (
+        <div className="text-center mt-40">
+            <h1 className="text-3xl mb-4">メールアドレスの確認</h1>
+            <p>確認メールが送信されました。メール内のリンクをクリックしてください。</p>
+            <button
+                onClick={handleResend}
+                className="mt-6 bg-blue-500 text-white px-4 py-2 rounded"
+            >
+                再送信
+            </button>
+            {message && <p className="mt-4 text-green-500">{message}</p>}
+        </div>
+    );
+}

--- a/src/app/auth/verify/page.tsx
+++ b/src/app/auth/verify/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useState, useRef } from 'react';
+import { applyActionCode } from 'firebase/auth';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { auth } from '@/lib/firebase';
+
+export default function VerifyEmailPage() {
+    const searchParams = useSearchParams();
+    const router = useRouter();
+    const hasRun = useRef(false);
+    const [status, setStatus] = useState<'verifying' | 'success' | 'error'>('verifying');
+
+    useEffect(() => {
+        const run = async () => {
+        const oobCode = searchParams.get('oobCode');
+
+        if (!oobCode || hasRun.current) {
+            return;
+        }
+        hasRun.current = true; // 以後は再実行しない
+
+        try {
+            await applyActionCode(auth, oobCode);
+            await auth.currentUser?.reload(); // メール認証フラグを更新
+            setStatus('success');
+        } catch (e) {
+            console.error("確認コードエラー:", e);
+            setStatus('error');
+        }
+        };
+
+        run();
+    }, [searchParams]);
+
+    if (status === 'verifying') {
+        return (
+            <div className="flex items-center justify-center min-h-[calc(100vh-64px)]">
+                <p className="text-gray-600 text-2xl">確認中です...</p>
+            </div>
+        );
+    }
+
+    if (status === 'error') {
+        return (
+            <div className="flex items-center justify-center min-h-[calc(100vh-64px)]">
+                <p className="text-red-500 text-xl">確認に失敗しました。リンクが無効か期限切れの可能性があります。</p>
+            </div>
+        );
+    }
+
+    if (status === 'success') {
+        return (
+            <div className="flex flex-col justify-center min-h-[calc(100vh-64px)] text-center">
+                <h1 className="text-2xl font-bold mb-4">メールアドレスの確認が完了しました！</h1>
+                <button
+                    onClick={() => {
+                    window.location.href = '/'; // 完全なリロード付き遷移
+                    }}
+                    className="mt-4 bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+                >
+                    トップページへ
+                </button>
+            </div>
+        );
+    }
+}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -40,63 +40,69 @@ export default function Header() {
             {loading ? (
                 <p className="text-sm">読み込み中...</p>
             ) : user ? (
+                user.emailVerified ? (
                 <div className="relative" ref={menuRef}>
-                <button
+                    <button
                     onClick={() => setMenuOpen(!menuOpen)}
                     className="hover:underline focus:outline-none"
                     aria-haspopup="true"
                     aria-expanded={menuOpen}
-                >
+                    >
                     {user.displayName ? `${user.displayName}さん` : user.email} ▼
-                </button>
+                    </button>
 
-                <AnimatePresence>
+                    <AnimatePresence>
                     {menuOpen && (
-                    <motion.ul
+                        <motion.ul
                         initial={{ opacity: 0, y: -10 }}
                         animate={{ opacity: 1, y: 0 }}
                         exit={{ opacity: 0, y: -10 }}
                         transition={{ duration: 0.2 }}
                         className="absolute right-0 mt-2 w-40 bg-white text-black rounded shadow-lg z-10"
-                    >
+                        >
                         <li>
                             <Link
-                                href="/quiz"
-                                className="block px-4 py-2 hover:bg-gray-200"
-                                onClick={() => setMenuOpen(false)}
+                            href="/quiz"
+                            className="block px-4 py-2 hover:bg-gray-200"
+                            onClick={() => setMenuOpen(false)}
                             >
-                                クイズ
+                            クイズ
                             </Link>
                         </li>
-                        
                         <li>
                             <Link
-                                href="/calendar"
-                                className="block px-4 py-2 hover:bg-gray-200"
-                                onClick={() => setMenuOpen(false)}
+                            href="/calendar"
+                            className="block px-4 py-2 hover:bg-gray-200"
+                            onClick={() => setMenuOpen(false)}
                             >
-                                カレンダー
+                            カレンダー
                             </Link>
                         </li>
-                        
                         <li>
                             <button
-                                onClick={handleLogout}
-                                className="w-full text-left px-4 py-2 hover:bg-gray-200"
+                            onClick={handleLogout}
+                            className="w-full text-left px-4 py-2 hover:bg-gray-200"
                             >
-                                ログアウト
+                            ログアウト
                             </button>
                         </li>
-                    </motion.ul>
+                        </motion.ul>
                     )}
-                </AnimatePresence>
+                    </AnimatePresence>
                 </div>
+                ) : (
+                <div className="flex items-center gap-4">
+                    <p className="text-yellow-200">メール確認待ち</p>
+                    <button onClick={handleLogout} className="hover:underline">
+                    ログアウト
+                    </button>
+                </div>
+                )
             ) : (
                 <div className="flex gap-4">
                     <Link href="/auth/register" className="hover:underline">
                         登録
                     </Link>
-                    
                     <Link href="/auth/login" className="hover:underline">
                         ログイン
                     </Link>

--- a/src/components/common/SubmitButton.tsx
+++ b/src/components/common/SubmitButton.tsx
@@ -6,9 +6,10 @@ type Props = {
     isSubmitting: boolean;
     children: React.ReactNode;
     className?: string;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
 };
 
-export default function SubmitButton({ isSubmitting, children }: Props) {
+export default function SubmitButton({ isSubmitting, children, className, onClick }: Props) {
     return (
         <button
         type="submit"

--- a/src/components/common/WithAuth.tsx
+++ b/src/components/common/WithAuth.tsx
@@ -10,13 +10,21 @@ export const withAuth = (Component: React.ComponentType) => {
         const router = useRouter();
 
         useEffect(() => {
-            if (!loading && !user) {
-                router.push('/auth/login');
+            if (!loading) {
+                if (!user) {
+                    router.push('/auth/login');
+                } else if (!user.emailVerified) {
+                    router.push('/auth/verify-email'); // メール未確認ユーザー向けのページへ
+                }
             }
         }, [user, loading]);
 
-        if (loading || !user) {
-            return <p className="text-center mt-20">読み込み中...</p>;
+        if (loading || !user || !user.emailVerified) {
+            return (
+                <div className="flex items-center justify-center min-h-screen">
+                    <p className="text-gray-600 text-2xl">読み込み中...</p>
+                </div>
+            );
         }
 
         return <Component {...props} />;

--- a/src/lib/firebaseAuth.ts
+++ b/src/lib/firebaseAuth.ts
@@ -3,6 +3,8 @@ import {
     signInWithEmailAndPassword,
     signOut,
     updateProfile,
+    sendEmailVerification,
+    sendPasswordResetEmail
 } from 'firebase/auth';
 import { auth } from '@/lib/firebase';
 
@@ -13,15 +15,23 @@ export const signUp = async (email: string, password: string, username: string) 
     // ユーザー名（displayName）を設定
     await updateProfile(user, { displayName: username });
 
+    await sendEmailVerification(user);
+
     return user;
 };
 
 export const signIn = async (email: string, password: string) => {
     return await signInWithEmailAndPassword(auth, email, password);
 };
+// signIn 関数は UserCredential を返すので、user を使って emailVerified を確認できます
+
 
 export const signOutUser = async () => {
     return await signOut(auth);
+};
+
+export const resetPassword = async (email: string) => {
+    return await sendPasswordResetEmail(auth, email);
 };
 
 // 認証済みのユーザーは user.getIdToken() メソッドを持っており、これを使って Firebase ID トークンを取得できます。Firebase Auth は内部的にIDトークン（JWT）を使って認証状態を管理している


### PR DESCRIPTION
メール認証
    会員登録後にメール認証ページへ遷移（再送信ボタンあり）
　メール内のリンクをクリックすると状態によって表示切り替え（認証成功or無効なリンク）
    認証成功画面のトップページボタンで画面遷移できる

パスワードリセット
　ログイン画面のパスワードを忘れた方はこちらをクリックするとメール送信画面へ遷移
　登録済みのメールアドレスを入力して送信ボタンをクリック
　メール内のリンクをクリックするとパスワード変更画面へ遷移

ログイン後のヘッダーメニューをユーザー名をクリックすることで開閉
メール未認証の状態でトップページやクイズページにアクセスできないよう制限